### PR TITLE
Issue-53: Fix Log Starter Time Format

### DIFF
--- a/src/Services/Validators/StartValidator.php
+++ b/src/Services/Validators/StartValidator.php
@@ -74,7 +74,7 @@ class StartValidator
         if (isset($this->time)) {
             if (! is_string($this->time)) {
                 throw new RunTimeException('Time must be a string');
-            } elseif (! preg_match('/^\d{2}:\d{2}/', $this->time)) {
+            } elseif (! preg_match('/^\d{2}:\d{2}$/', $this->time)) {
                 throw new RunTimeException('Time must be in hh:ii format');
             }
         }

--- a/tests/Unit/Validators/StartValidatorTest.php
+++ b/tests/Unit/Validators/StartValidatorTest.php
@@ -27,6 +27,7 @@ class StartValidatorTest extends TestCase
             ['Issue-8', 'string', null, 'Time must be in hh:ii format'],
             ['Issue-8', '1:01', null, 'Time must be in hh:ii format'],
             ['Issue-8', '01:0', null, 'Time must be in hh:ii format'],
+            ['Issue-53', '10:10AM', null, 'Time must be in hh:ii format'],
             ['Issue-8', null, 1, 'Description must be a string'],
             ['Issue-8', null, [1], 'Description must be a string'],
         ];


### PR DESCRIPTION
Log starter command accepts AM/PM string alongside the provided time which causes the time formatter to throw PHP exceptions. Fixed by not allowing wrong time formats through the log starter command validator.